### PR TITLE
Fix Param deprecation warnings

### DIFF
--- a/holypipette/gui/camera.py
+++ b/holypipette/gui/camera.py
@@ -1006,7 +1006,7 @@ class ConfigGui(QtWidgets.QWidget):
         self.save_button.setIcon(qta.icon('fa.download'))
         top_row.addWidget(self.save_button)
         layout.addLayout(top_row)
-        all_params = config.params()
+        all_params = config.param.params()
         self.value_widgets = {}
         for category, params in config.categories:
             box = QtWidgets.QGroupBox(category)
@@ -1064,7 +1064,7 @@ class ConfigGui(QtWidgets.QWidget):
         if key not in self.value_widgets:
             return
 
-        param_obj  = self.config.params()[key]
+        param_obj  = self.config.param.params()[key]
         magnitude  = getattr(param_obj, 'magnitude', 1)
 
         # Only scale numeric values; leave strings / bools intact

--- a/holypipette/utils/config.py
+++ b/holypipette/utils/config.py
@@ -28,7 +28,7 @@ class Config(param.Parameterized):
             logging.debug('Config value changed: %s = %s', key, value)
 
     def to_dict(self):
-        return {name: getattr(self, name) for name in self.params()
+        return {name: getattr(self, name) for name in self.param.params()
                 if name != 'name'}
 
     def from_dict(self, config_dict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ onnxruntime_gpu==1.19.2
 opencv_python==4.10.0.84
 opencv_python_headless==4.10.0.84
 pandas==2.2.3
-param==1.13.0
+param>=2.0
 pco==0.1.3
 Pillow==11.0.0
 pycocotools==2.0.8

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -17,7 +17,7 @@ onnxruntime_gpu==1.19.2
 opencv_python==4.10.0.84
 opencv_python_headless==4.10.0.84
 pandas==2.2.3
-param==1.13.0
+param>=2.0
 pco==0.1.3
 Pillow==11.0.0
 pycocotools==2.0.8


### PR DESCRIPTION
## Summary
- update Parameterized usage to new `param.param` style
- require param 2.x in both requirement files

## Testing
- `python -m py_compile $(git ls-files '*.py')`