### PR TITLE
Fix pressure acquisition for fake rig

### DIFF
--- a/holypipette/devices/pressurecontroller/BasePressureController.py
+++ b/holypipette/devices/pressurecontroller/BasePressureController.py
@@ -137,6 +137,11 @@ class FakePressureController(PressureController):
     def __init__(self):
         super(FakePressureController, self).__init__()
         self.pressure = 0
+        # Start the acquisition thread automatically so that
+        # ``get_last_acquisition`` returns values when used in the
+        # fake rig setup.  Without this the GUI raises an exception
+        # because no pressure measurements are available.
+        self.start_acquisition()
 
     def measure(self, port=0):
         """

--- a/holypipette/gui/graph.py
+++ b/holypipette/gui/graph.py
@@ -361,9 +361,11 @@ class EPhysGraph(QWidget):
         pressure = self.graph_interface.get_last_pressure()
         if pressure is not None:
             pressure = int(pressure)
-        else: 
+        else:
+            # When running with a fake rig there might not yet be
+            # any pressure measurements.  Avoid raising an exception
+            # and simply display 0 mbar until data is available.
             pressure = 0
-            raise ValueError("No pressure data available")
         pressure_set = int(self.graph_interface.get_pressure())
         if pressure is not None:
             self.pressureData.append(pressure)


### PR DESCRIPTION
## Summary
- start `FakePressureController` acquisition automatically
- avoid raising on missing pressure data in the graph view

## Testing
- `python -m py_compile holypipette/devices/pressurecontroller/BasePressureController.py holypipette/gui/graph.py`
