### PR TITLE
Fix deprecated param usage

### DIFF
--- a/holypipette/config.py
+++ b/holypipette/config.py
@@ -28,7 +28,10 @@ class Config(param.Parameterized):
             logging.debug('Config value changed: %s = %s', key, value)
 
     def to_dict(self):
-        return {name: getattr(self, name) for name in self.params()
+        # ``params`` on ``param.Parameterized`` is deprecated; iterate over
+        # ``self.param`` (a mapping of parameter names to Parameter objects)
+        # instead.
+        return {name: getattr(self, name) for name in self.param
                 if name != 'name'}
 
     def from_dict(self, config_dict):

--- a/holypipette/gui/camera.py
+++ b/holypipette/gui/camera.py
@@ -1006,7 +1006,9 @@ class ConfigGui(QtWidgets.QWidget):
         self.save_button.setIcon(qta.icon('fa.download'))
         top_row.addWidget(self.save_button)
         layout.addLayout(top_row)
-        all_params = config.params()
+        # ``params`` has been deprecated in ``param``; use ``param`` directly
+        # which behaves like a dictionary mapping parameter names to objects.
+        all_params = config.param
         self.value_widgets = {}
         for category, params in config.categories:
             box = QtWidgets.QGroupBox(category)
@@ -1064,7 +1066,9 @@ class ConfigGui(QtWidgets.QWidget):
         if key not in self.value_widgets:
             return
 
-        param_obj  = self.config.params()[key]
+        # Access parameter objects via ``param`` to avoid using the deprecated
+        # ``params`` method
+        param_obj  = self.config.param[key]
         magnitude  = getattr(param_obj, 'magnitude', 1)
 
         # Only scale numeric values; leave strings / bools intact


### PR DESCRIPTION
## Summary
- remove deprecated `params()` calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`
