### PR TITLE
Remove OB1 references from pressure docs

### DIFF
--- a/docs/images/code_structure.svg
+++ b/docs/images/code_structure.svg
@@ -622,7 +622,7 @@
              y="12860"
              id="tspan503"><tspan
                id="tspan505"
-               style="fill:#000000;stroke:none">OB1</tspan></tspan></tspan></text>
+               style="fill:#000000;stroke:none"></tspan></tspan></tspan></text>
 </g></g><g
      class="com.sun.star.drawing.CustomShape"
      id="g507"

--- a/docs/pressure.rst
+++ b/docs/pressure.rst
@@ -1,20 +1,48 @@
 Pressure control
 ================
 
-Holy Pipette can control a pressure controller.
-Classes inherit the `.PressureController` class, which implements
-three methods. Currently only Elveflow's ``OB1`` controller is implemented.
+Holy Pipette can control different pressure controllers. All classes inherit
+from `.PressureController` and expose the same ``set_pressure`` and ``measure``
+API.
 
-Example::
+Supported controllers include:
 
-    controller = OB1()
-    controller.set_pressure(25, port = 0)
-    pressure = controller.measure(port = 0)
-    controller.ramp(amplitude = -100., duration = 1., port = 0)
+- `.IBBPressureController`
+- `.MoscowPressureController`
+- `.FakePressureController` (development)
 
-Pressure is mBar.
+Examples
+--------
+
+Using the :class:`IBBPressureController`::
+
+    from holypipette.devices.pressurecontroller import IBBPressureController
+    import serial
+
+    port = serial.Serial('COM5', 9600, timeout=0)
+    controller = IBBPressureController(channel=1, arduinoSerial=port)
+    controller.set_pressure(25)
+    pressure = controller.measure()
+
+The :class:`MoscowPressureController` uses separate ports for commands and
+sensor readings::
+
+    from holypipette.devices.pressurecontroller import MoscowPressureController
+    import serial
+
+    ctrl_serial = serial.Serial('COM5', 9600, timeout=0)
+    read_serial = serial.Serial('COM9', 9600, timeout=0)
+    controller = MoscowPressureController(channel=1,
+                                          controllerSerial=ctrl_serial,
+                                          readerSerial=read_serial)
+    controller.set_pressure(25)
+    pressure = controller.measure()
+
+Pressure values are expressed in mBar.
 
 Fake pressure controller
 ------------------------
 For development purposes, a `.FakePressureController` is implemented.
-It behaves as a pressure controller, except it is not connected to an actual device.
+It behaves as a pressure controller, except it is not connected to an
+actual device.
+


### PR DESCRIPTION
## Summary
- drop OB1 from pressure controller list and usage docs
- scrub `OB1` label from the code structure diagram

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
