### PR TITLE
Add cell metadata logging

### DIFF
--- a/patch_gui.py
+++ b/patch_gui.py
@@ -36,7 +36,7 @@ def main():
     recording_state_manager = RecordingStateManager()
 
     pipette_controller = PipetteInterface(stage, microscope, camera, unit, cellSorterManip, cellSorterController)
-    patch_controller = AutoPatchInterface(amplifier, daq, pressure, pipette_controller)
+    patch_controller = AutoPatchInterface(amplifier, daq, pressure, pipette_controller, recording_state_manager)
     graph_interface = GraphInterface(amplifier, daq, pressure, recording_state_manager)
     gui = PatchGui(camera, pipette_controller, patch_controller, recording_state_manager)
     graphs = EPhysGraph(graph_interface, recording_state_manager)


### PR DESCRIPTION
## Summary
- extend `EPhysLogger` with ability to store cell metadata (image, stage and pixel coords)
- record cell pixel coordinates in `AutoPatchInterface.add_cell`
- save metadata when running protocols
- keep lists in sync when removing or escaping cells
- pass `RecordingStateManager` to `AutoPatchInterface` from `patch_gui.py`

## Testing
- `pytest -q`
