### PR TITLE
Apply stage axis flips from config and remove hardcoded Y inversion

### DIFF
--- a/holypipette/controller/patch.py
+++ b/holypipette/controller/patch.py
@@ -449,8 +449,7 @@ class AutoPatcher(TaskController):
         stage_pos = self.calibrated_stage.pixels_to_um(self.calibrated_stage.reference_position())
         # print(f"Stage position: {stage_pos}")
 
-        # FOR BO'S RIG - may need to change if a different rig is calibrated with different negatives applied to the axes
-        stage_pos[1]=-stage_pos[1] #invert y axis
+        # Stage sign conventions are handled in calibration; avoid double-inverting here.
 
 
         disp = np.zeros(3)
@@ -1336,5 +1335,4 @@ class AutoPatcher(TaskController):
         '''
          takes in 
         '''
-
 

--- a/holypipette/devices/manipulator/calibratedunit.py
+++ b/holypipette/devices/manipulator/calibratedunit.py
@@ -175,7 +175,11 @@ class CalibratedUnit(ManipulatorUnit):
         '''
         if self.Minv.shape[1] == 2: #2x2 stage movement
             xy = dot(self.Minv, pos_pixels[0:2]) + self.r0_inv[0:2]
-            return np.array([xy[0], -xy[1], 0])
+            if self.config.stage_x_axis_flip:
+                xy[0] = -xy[0]
+            if self.config.stage_y_axis_flip:
+                xy[1] = -xy[1]
+            return np.array([xy[0], xy[1], 0])
         else: #3x3 pipette movement
             return dot(self.Minv, pos_pixels) + self.r0_inv
     
@@ -185,6 +189,10 @@ class CalibratedUnit(ManipulatorUnit):
         '''
         if self.Minv.shape[1] == 2: #2x2 stage movement
             xy = dot(self.Minv, pos_pixels[0:2])
+            if self.config.stage_x_axis_flip:
+                xy[0] = -xy[0]
+            if self.config.stage_y_axis_flip:
+                xy[1] = -xy[1]
             return np.array([xy[0], xy[1], 0])
         else: #3x3 pipette movement
             return dot(self.Minv, pos_pixels)
@@ -237,8 +245,7 @@ class CalibratedUnit(ManipulatorUnit):
             self.info(f'desired position: {pos_pixels}')
             self.info(f'Stage reference position: {self.stage.reference_position()}')
             pos_micron = self.pixels_to_um(pos_pixels - self.stage.reference_position()) # position vector (um) in manipulator unit system
-            # FOR BO'S RIG - may need to change if a different rig is calibrated with different negatives applied to the axes
-            pos_micron[1] = -pos_micron[1] # Invert y axis
+            # pixels_to_um already handles any stage-axis sign conventions; do not flip again here.
             self.info(f'Position in um: {pos_micron}')
             self.absolute_move(pos_micron)
             self.wait_until_still()
@@ -247,8 +254,7 @@ class CalibratedUnit(ManipulatorUnit):
             self.info(f'desired position: {pos_pixels}')
             self.info(f'Stage reference position (used for pipette calibration): {self.stage.reference_position()}')
             pos_micron = self.pixels_to_um(pos_pixels - self.stage.reference_position())
-            # FOR BO'S RIG - may need to change if a different rig is calibrated with different negatives applied to the axes
-            pos_micron[1] = -pos_micron[1] # Invert y axis
+            # pixels_to_um already handles any stage-axis sign conventions; do not flip again here.
             self.info(f'Position in um: {pos_micron}')
             self.absolute_move(pos_micron)
             self.wait_until_still()


### PR DESCRIPTION
### Motivation
- Prevent double-negatives by centralizing stage-axis sign handling in the calibration conversion instead of ad-hoc flips elsewhere.
- Make pixel-to-micron conversions honor per-rig configuration flags for axis orientation (`stage_x_axis_flip`, `stage_y_axis_flip`).
- Remove a hardcoded Y inversion in the patch workflow which conflicted with calibrated sign conventions.

### Description
- In `pixels_to_um` apply `self.config.stage_x_axis_flip` and `self.config.stage_y_axis_flip` to flip `xy` components instead of always inverting Y.  
- In `pixels_to_um_relative` apply the same per-axis flip logic for relative conversions.  
- Remove the manual `pos_micron[1] = -pos_micron[1]` flips from `reference_move` and update the inline comment to note that `pixels_to_um` handles stage-axis sign conventions.  
- Remove the hardcoded `stage_pos[1] = -stage_pos[1]` from `holypipette/controller/patch.py` and replace it with a comment to avoid double-inverting calibrated positions.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967edeb9e28832fa56292758cbfcd81)